### PR TITLE
Azure ci for Windows

### DIFF
--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -51,8 +51,9 @@ jobs:
       stack exec --stack-yaml $(YAML_FILE) hoogle generate
     displayName: Build Test-dependencies
   - bash: |
+      # TODO: try to install automatically (`choco install z3` fails)
       curl -L https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-x64-win.zip -o /mingw64/z3.zip
-      unzip -o /migw64/z3.zip -d /mingw64
+      unzip -o /mingw64/z3.zip -d /mingw64
     displayName: "Install Runtime Test-Dependencies: z3"
   - bash: |
       source .azure/windows.bashrc

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -51,11 +51,12 @@ jobs:
       stack exec --stack-yaml $(YAML_FILE) hoogle generate
     displayName: Build Test-dependencies
   - bash: |
-      pacman -S --noconfirm mingw-w64-x86_64-z3  
+      curl -L https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-x64-win.zip -o /mingw64/z3.zip
+      unzip -o /migw64/z3.zip -d /mingw64
     displayName: "Install Runtime Test-Dependencies: z3"
   - bash: |
       source .azure/windows.bashrc
-      curl -L https://downloads.haskell.org/cabal/cabal-install-$CABAL_VERSION/cabal-install-$CABAL_VERSION-x86_64-unknown-mingw32.zip -o $LOCAL_BIN_PATH/cabal-$CABAL_VERSION.zip
+      curl -L https://downloads.haskell.org/cabal/cabal-install-$CABAL_VERSION/cabal-install-$CABAL_VERSION_FULL.zip -o $LOCAL_BIN_PATH/cabal-$CABAL_VERSION.zip
       unzip -o $LOCAL_BIN_PATH/cabal-$CABAL_VERSION.zip -d $LOCAL_BIN_PATH
       cabal v1-update
       stack setup --stack-yaml=stack-8.2.2.yaml

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -52,7 +52,7 @@ jobs:
     displayName: Build Test-dependencies
   - bash: |
       pacman -S --noconfirm mingw-w64-x86_64-z3  
-    displayName: Install Runtime Test-Dependencies: z3
+    displayName: "Install Runtime Test-Dependencies: z3"
   - bash: |
       source .azure/windows.bashrc
       curl -L https://downloads.haskell.org/cabal/cabal-install-$CABAL_VERSION/cabal-install-$CABAL_VERSION-x86_64-unknown-mingw32.zip -o $LOCAL_BIN_PATH/cabal-$CABAL_VERSION.zip
@@ -60,7 +60,7 @@ jobs:
       cabal v1-update
       stack setup --stack-yaml=stack-8.2.2.yaml
       cabal v1-install liquidhaskell-0.8.2.4 --symlink-bindir=$LOCAL_BIN_PATH -w $(stack path --stack-yaml=stack-8.2.2.yaml --compiler-exe)
-    displayName: Install Runtime Test-Dependencies: liquidhaskell
+    displayName: "Install Runtime Test-Dependencies: liquidhaskell"
   - bash: |
       source .azure/windows.bashrc
       stack test --stack-yaml $(YAML_FILE) :unit-test

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -29,8 +29,7 @@ jobs:
       git submodule update --init
     displayName: Sync submodules
   - bash: |
-      export STACK_ROOT="$(Build.SourcesDirectory)"/.stack-root
-      curl -sSkL http://www.stackage.org/stack/windows-i386 -o /usr/bin/stack.zip
+      curl -sSkL http://www.stackage.org/stack/windows-x86_64 -o /usr/bin/stack.zip
       unzip -o /usr/bin/stack.zip -d /usr/bin/
     displayName: Install stack
   - bash: |
@@ -38,7 +37,7 @@ jobs:
       stack setup --stack-yaml $(YAML_FILE)
     displayName: Install GHC
   - bash: |
-      source .azure/linux.bashrc
+      source .azure/windows.bashrc
       stack --stack-yaml $(YAML_FILE) --install-ghc build --only-dependencies
     displayName: Build dependencies
   - bash: |
@@ -55,10 +54,11 @@ jobs:
       stack exec --stack-yaml $(YAML_FILE) hoogle generate
       choco install z3
       cabal v1-update
+      mkdir /usr/local -p
       curl -L https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-x64-win.zip -o /usr/local/z3.zip
       unzip -o /usr/local/z3.zip -d /usr/local/
       stack setup --stack-yaml=stack-8.2.2.yaml
-      cabal v1-install liquidhaskell-0.8.2.4 --symlink-bindir=$HOME/.local/bin -w $(stack path --stack-yaml=stack-8.2.2.yaml --compiler-exe)
+      cabal v1-install liquidhaskell-0.8.2.4 --symlink-bindir=$LOCAL_BIN_PATH -w $(stack path --stack-yaml=stack-8.2.2.yaml --compiler-exe)
     displayName: Build Test-dependencies
   - bash: |
       source .azure/windows.bashrc

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -52,8 +52,9 @@ jobs:
     displayName: Build Test-dependencies
   - bash: |
       # TODO: try to install automatically (`choco install z3` fails)
-      curl -L https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-x64-win.zip -o /mingw64/z3.zip
-      unzip -o /mingw64/z3.zip -d /mingw64
+      mkdir -p /usr/local
+      curl -L https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-x64-win.zip -o /usr/local/z3.zip
+      unzip -o /usr/local/z3.zip -d /usr/local/
     displayName: "Install Runtime Test-Dependencies: z3"
   - bash: |
       source .azure/windows.bashrc

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -48,18 +48,19 @@ jobs:
       source .azure/windows.bashrc
       stack build --stack-yaml $(YAML_FILE) --test --bench --only-dependencies
       stack install --stack-yaml $(YAML_FILE) # `hie` binary required for tests
-      # TODO: get `cabal` binary from somewhere else?
-      stack setup --stack-yaml=stack-8.6.5.yaml
-      stack install --stack-yaml=stack-8.6.5.yaml cabal-install-2.4.1.0
       stack exec --stack-yaml $(YAML_FILE) hoogle generate
-      choco install z3
+    displayName: Build Test-dependencies
+  - bash: |
+      pacman -S --noconfirm mingw-w64-x86_64-z3  
+    displayName: Install Runtime Test-Dependencies: z3
+  - bash: |
+      source .azure/windows.bashrc
+      curl -L https://downloads.haskell.org/cabal/cabal-install-$CABAL_VERSION/cabal-install-$CABAL_VERSION-x86_64-unknown-mingw32.zip -o $LOCAL_BIN_PATH/cabal-$CABAL_VERSION.zip
+      unzip -o $LOCAL_BIN_PATH/cabal-$CABAL_VERSION.zip -d $LOCAL_BIN_PATH
       cabal v1-update
-      mkdir /usr/local -p
-      curl -L https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-x64-win.zip -o /usr/local/z3.zip
-      unzip -o /usr/local/z3.zip -d /usr/local/
       stack setup --stack-yaml=stack-8.2.2.yaml
       cabal v1-install liquidhaskell-0.8.2.4 --symlink-bindir=$LOCAL_BIN_PATH -w $(stack path --stack-yaml=stack-8.2.2.yaml --compiler-exe)
-    displayName: Build Test-dependencies
+    displayName: Install Runtime Test-Dependencies: liquidhaskell
   - bash: |
       source .azure/windows.bashrc
       stack test --stack-yaml $(YAML_FILE) :unit-test

--- a/.azure/windows.bashrc
+++ b/.azure/windows.bashrc
@@ -1,1 +1,3 @@
-export PATH=$HOME/.local/bin:$PATH
+export STACK_ROOT="C:\\sr"
+export LOCAL_BIN_PATH=$LOCALAPPDATA\\bin
+export PATH=$LOCAL_BIN_PATH:$PATH

--- a/.azure/windows.bashrc
+++ b/.azure/windows.bashrc
@@ -2,3 +2,4 @@ export STACK_ROOT="C:\\sr"
 export LOCAL_BIN_PATH=$(cygpath $APPDATA\\local\\bin)
 export PATH=$LOCAL_BIN_PATH:$PATH
 export CABAL_VERSION=2.4.1.0
+export CABAL_VERSION_FULL=$CABAL_VERSION-x86_64-unknown-mingw32

--- a/.azure/windows.bashrc
+++ b/.azure/windows.bashrc
@@ -1,3 +1,4 @@
 export STACK_ROOT="C:\\sr"
 export LOCAL_BIN_PATH=$(cygpath $APPDATA\\local\\bin)
 export PATH=$LOCAL_BIN_PATH:$PATH
+export CABAL_VERSION=2.4.1.0

--- a/.azure/windows.bashrc
+++ b/.azure/windows.bashrc
@@ -1,3 +1,3 @@
 export STACK_ROOT="C:\\sr"
-export LOCAL_BIN_PATH=$LOCALAPPDATA\\bin
+export LOCAL_BIN_PATH=$(cygpath $APPDATA\\local\\bin)
 export PATH=$LOCAL_BIN_PATH:$PATH


### PR DESCRIPTION
I've tested the config in this build: https://dev.azure.com/jneira/haskell-ide-engine/_build/results?buildId=47 (but the build of the last commit is https://dev.azure.com/jneira/haskell-ide-engine/_build/results?buildId=49)
With this, the windows builds fail in the run test step as expected.
I've separated the install of liquid haskell and z3 in different steps, let me know if you prefer the actual steps separation.
The build downloads cabal from `https://downloads.haskell.org` instead build it with stack. 
I am not sure if the manual install of z3 is valid, in mingw64 the dir `/usr/local` ever exists.
